### PR TITLE
Support for new hierarchical structure in documentation for appium

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ Thanks to the following people who have submitted pull requests:
 
 - [@chrissrogers](https://github.com/chrissrogers)
 - [@bootstraponline](https://github.com/bootstraponline)
+
+Specific to appium docs
+-------------------------
+
+- `rake md[/../appium/docs/en]` for creating a single markdown from documents of appium.
+- `rake build`
+- `bundle exec middleman server` to start test server
+-  For appium specific settings and options related to markdowns see api-docs.yml

--- a/api-docs.yml
+++ b/api-docs.yml
@@ -1,0 +1,77 @@
+ignore:
+  - contributing-to-appium
+
+folder-order:
+  - about-appium
+  - appium-setup
+  - writing-running-appium
+  - advanced-concepts
+
+folder-map:
+
+  about-appium:
+    label: About Appium
+    file-order:
+      - intro.md
+      - appium-clients.md
+  appium-setup:
+    label: Setting up Appium
+    file-order:
+      - platform-support.md
+      - real-devices.md
+      - running-on-osx.md
+      - running-on-windows.md
+      - running-on-linux.md
+      - android-hax-emulator.md
+      - ios-deploy.md
+      - troubleshooting.md
+  writing-running-appium:
+    label: Running Appium tests
+    file-order:
+      - server-args.md
+      - caps.md
+      - finding-elements.md
+      - mobile-web.md
+      - running-tests.md
+      - touch-actions.md
+      - appium-bindings.md
+      - ios_predicate.md
+      - network_connection.md
+      - uiautomator_uiselector.md
+      - unicode.md
+  advanced-concepts:
+      label: Advanced Concepts
+      file-order:
+        - grid.md
+        - hybrid.md
+        - migrating-to-1-0.md
+
+file-order-older-versions:
+      - intro.md
+      - README.md
+      - platform-support.md
+      - real-devices.md
+      - running-on-osx.md
+      - running-on-windows.md
+      - running-on-linux.md
+      - running-tests.md
+      - android-hax-emulator.md
+      - android_coverage.md
+      - server-args.md
+      - caps.md
+      - finding-elements.md
+      - gestures.md
+      - grid.md
+      - hybrid.md
+      - ios-deploy.md
+      - mobile-web.md
+      - mobile_methods.md
+      - touch-actions.md
+      - troubleshooting.md
+      - migrating-to-1-0.md
+
+ignore-files-older-versions:
+      - grunt.md
+      - how-to-write-docs.md
+      - credits.md
+      - style-guide.md

--- a/source/javascripts/app/toc.js
+++ b/source/javascripts/app/toc.js
@@ -9,7 +9,7 @@
 
   function toc () {
     toc = $("#toc").tocify({
-      selectors: 'h1, h2',
+      selectors: 'h1, h2, h3',
       extendPage: false,
       theme: 'none',
       smoothScroll: false,
@@ -34,4 +34,3 @@
   }
 
 })(window);
-

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -147,6 +147,10 @@ html, body {
       padding-left: $nav-padding + $nav-indent;
       font-size: 12px;
     }
+
+    .tocify-subheader .tocify-item>a {
+      padding-left: $nav-padding + 2*$nav-indent;
+    }
     // These items make for a slight embossed look for the subheader.
     // "Why not put the borders in the subheader?" you ask.
     // "Because then the animation isn't as smooth," I reply.


### PR DESCRIPTION
-Support for restructuring of appium documentation to provide support to hierarchical
-Supports [This directory sturcture](https://github.com/moizjv/appium/tree/documentation/docs/en) , it includes having directories in docs and also changing headings from `h1` to `h2` and `h2` to `h3` to accommodate new folder name to have heading `h1` and support 3 level hierarchy .
-Tested using 

```
`rake md[../../appium/docs/en]` 
`rake build` 
`bundle exec middleman server`
```

-New yaml support for labeling folders, ignore list and ordering  
-Will look like this
![screen shot 2014-07-02 at 5 55 44 pm](https://cloud.githubusercontent.com/assets/1308607/3464442/0e37dbfe-024d-11e4-9697-b1b39ca47c7e.png)
